### PR TITLE
Added type='button' for all buttons to avoid unecessary conflicts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -250,6 +250,7 @@ var Duallist = function (_Component) {
             _react2.default.createElement(
               'button',
               {
+                type: 'button',
                 className: 'btn-move',
                 onClick: this.onMoveAllRight
               },
@@ -258,6 +259,7 @@ var Duallist = function (_Component) {
             _react2.default.createElement(
               'button',
               {
+                type: 'button',
                 className: 'btn-move',
                 onClick: this.onMoveRight
               },
@@ -270,6 +272,7 @@ var Duallist = function (_Component) {
             _react2.default.createElement(
               'button',
               {
+                type: 'button',
                 className: 'btn-move',
                 onClick: this.onMoveLeft
               },
@@ -278,6 +281,7 @@ var Duallist = function (_Component) {
             _react2.default.createElement(
               'button',
               {
+                type: 'button',
                 className: 'btn-move',
                 onClick: this.onMoveAllLeft
               },
@@ -309,6 +313,7 @@ var Duallist = function (_Component) {
             _react2.default.createElement(
               'button',
               {
+                type: 'button',
                 className: 'btn-move',
                 disabled: this.state.rightSelected.length !== 1,
                 onClick: this.onMoveAllUp
@@ -318,6 +323,7 @@ var Duallist = function (_Component) {
             _react2.default.createElement(
               'button',
               {
+                type: 'button',
                 className: 'btn-move',
                 disabled: this.state.rightSelected.length !== 1,
                 onClick: this.onMoveUp
@@ -331,6 +337,7 @@ var Duallist = function (_Component) {
             _react2.default.createElement(
               'button',
               {
+                type: 'button',
                 className: 'btn-move',
                 disabled: this.state.rightSelected.length !== 1,
                 onClick: this.onMoveDown
@@ -340,6 +347,7 @@ var Duallist = function (_Component) {
             _react2.default.createElement(
               'button',
               {
+                type: 'button',
                 className: 'btn-move',
                 disabled: this.state.rightSelected.length !== 1,
                 onClick: this.onMoveAllDown

--- a/src/index.js
+++ b/src/index.js
@@ -213,12 +213,14 @@
          <div className="react-listbox-center-toolbar">
            <div className="move-right">
              <button
+               type="button"
                className="btn-move"
                onClick={this.onMoveAllRight}
              >
                {moveAllRightIcon}
              </button>
              <button
+               type="button"
                className="btn-move"
                onClick={this.onMoveRight}
              >
@@ -227,12 +229,14 @@
            </div>
            <div className="move-left">
              <button
+               type="button"
                className="btn-move"
                onClick={this.onMoveLeft}
              >
                {moveLeftIcon}
              </button>
              <button
+               type="button"
                className="btn-move"
                onClick={this.onMoveAllLeft}
              >
@@ -255,6 +259,7 @@
            <div className="react-listbox-right-toolbar">
              <div className="move-top">
                <button
+                 type="button"
                  className="btn-move"
                  disabled={this.state.rightSelected.length !== 1}
                  onClick={this.onMoveAllUp}
@@ -262,6 +267,7 @@
                  {moveTopIcon}
                </button>
                <button
+                 type="button"
                  className="btn-move"
                  disabled={this.state.rightSelected.length !== 1}
                  onClick={this.onMoveUp}
@@ -271,6 +277,7 @@
              </div>
              <div className="move-bottom">
                <button
+                 type="button"
                  className="btn-move"
                  disabled={this.state.rightSelected.length !== 1}
                  onClick={this.onMoveDown}
@@ -278,6 +285,7 @@
                  {moveDownIcon}
                </button>
                <button
+                 type="button"
                  className="btn-move"
                  disabled={this.state.rightSelected.length !== 1}
                  onClick={this.onMoveAllDown}


### PR DESCRIPTION
When using Formik with Duallist, it display an Warning since the Duallist buttons don't have the "type" property, and also, some browsers makes buttons without this property as "submit" buttons by defaults.

Therefore, here's a pull requests adding this property.

Great plugin by the way :)